### PR TITLE
Adds a few missing python dependencies

### DIFF
--- a/braindrAnalysis/version.py
+++ b/braindrAnalysis/version.py
@@ -70,4 +70,4 @@ MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
 PACKAGE_DATA = {'braindrAnalysis': [pjoin('data', '*')]}
-REQUIRES = ["numpy", "simplejson", "pandas", "sklearn", "xgboost"]
+REQUIRES = ["numpy", "simplejson", "pandas", "sklearn", "xgboost", "tensorflow", "scikit-image", "keras"]


### PR DESCRIPTION
The package import statement fails if the following python packages are not already installed on the system. This PR adds these python packages to the list of required packages.

Packages missing => "tensorflow", "scikit-image", "keras"